### PR TITLE
Monkey patch for react-mounter.

### DIFF
--- a/lib/_init.js
+++ b/lib/_init.js
@@ -2,3 +2,5 @@
 FlowRouter = new Router();
 FlowRouter.Router = Router;
 FlowRouter.Route = Route;
+
+Package['kadira:flow-router-ssr'] = {FlowRouter};


### PR DESCRIPTION
This way react-mounter thinks kadira:flow-router-ssr is present and we do not have to manually mess with the code in it's dist directory.